### PR TITLE
Fix Ruby 2.7.0 warnings

### DIFF
--- a/lib/odnoklassniki/connection.rb
+++ b/lib/odnoklassniki/connection.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'faraday_middleware'
 
 module Odnoklassniki
   module Connection

--- a/lib/odnoklassniki/version.rb
+++ b/lib/odnoklassniki/version.rb
@@ -1,3 +1,3 @@
 module Odnoklassniki
-  VERSION = '0.0.1'
+  VERSION = '0.0.3'
 end

--- a/odnoklassniki.gemspec
+++ b/odnoklassniki.gemspec
@@ -17,9 +17,8 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ['lib']
-  s.add_dependency "faraday",            '~> 0.9',  '>= 0.9.0'
-  s.add_dependency "faraday_middleware", '~> 0.9',  '>= 0.9.0'
-  s.add_dependency "multi_json",         '~> 1.10', '>= 1.10.0'
+  s.add_dependency 'faraday',                        '>= 0.9', '< 2'
+  s.add_dependency 'multi_json',                     '~> 1.10', '>= 1.10.0'
   s.add_development_dependency 'pry',                '0.10.1'
   s.add_development_dependency 'byebug',             '3.5.1'
   s.add_development_dependency 'pry-byebug',         '3.0.0'


### PR DESCRIPTION
Updates:

- Relax `faraday` dependency version.
- Remove unused `faraday_middleware` dependency.
- Bump version to 0.0.3.